### PR TITLE
feat: article reading-experience (copy code, reading time, RSS, OG, ⌘K)

### DIFF
--- a/app/articles/[slug]/opengraph-image.tsx
+++ b/app/articles/[slug]/opengraph-image.tsx
@@ -1,0 +1,77 @@
+import fs from 'fs'
+import { ImageResponse } from 'next/og'
+import path from 'path'
+
+export const alt = 'Article on azazahamed.com'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// Read only the frontmatter title — no need to compile the whole MDX for an image.
+function getTitle(slug: string): string {
+  try {
+    const raw = fs.readFileSync(
+      path.join(process.cwd(), 'content', `${slug}.mdx`),
+      'utf8',
+    )
+    const match = raw.match(/^title:\s*['"]?(.+?)['"]?\s*$/m)
+    return match?.[1]?.trim() ?? 'Azaz Ahamed'
+  } catch {
+    return 'Azaz Ahamed'
+  }
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const title = getTitle(slug)
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px',
+        background: '#0B0E14',
+        color: '#E6EAF2',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', fontSize: 30 }}>
+        <span style={{ color: '#5b6472' }}>{'// '}</span>
+        <span style={{ color: '#38E1C6' }}>azazahamed.com</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 68,
+          fontWeight: 700,
+          lineHeight: 1.12,
+          letterSpacing: '-0.02em',
+          maxWidth: '1000px',
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', fontSize: 28 }}>
+        <div
+          style={{
+            width: 44,
+            height: 3,
+            background: '#38E1C6',
+            marginRight: 20,
+          }}
+        />
+        <span style={{ color: '#8A93A6' }}>
+          Full-stack · systems engineering
+        </span>
+      </div>
+    </div>,
+    size,
+  )
+}

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -73,13 +73,16 @@ const ArticlePage = async ({ params }: ArticleParams) => {
                 <h1 className='mt-6 font-mono text-3xl leading-[1.15] font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-zinc-50'>
                   {meta.title}
                 </h1>
-                <time
-                  dateTime={meta.date}
-                  className='order-first flex items-center font-mono text-xs text-zinc-400 dark:text-zinc-500'
-                >
+                <div className='order-first flex items-center font-mono text-xs text-zinc-400 dark:text-zinc-500'>
                   <span className='h-4 w-0.5 rounded-full bg-accent-400/70' />
-                  <span className='ml-3'>{formatDate(meta.date)}</span>
-                </time>
+                  <time dateTime={meta.date} className='ml-3'>
+                    {formatDate(meta.date)}
+                  </time>
+                  <span className='mx-2 text-zinc-300 dark:text-zinc-600'>
+                    ·
+                  </span>
+                  <span>{meta.readingTime} min read</span>
+                </div>
               </header>
               <Prose className='mt-8'>{content}</Prose>
             </article>

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,54 @@
+import { getAllPostsMeta } from '@/lib/mdx'
+
+const SITE = 'https://azazahamed.com'
+
+function escapeXml(value: string): string {
+  return value.replace(
+    /[<>&'"]/g,
+    (c) =>
+      ({
+        '<': '&lt;',
+        '>': '&gt;',
+        '&': '&amp;',
+        "'": '&apos;',
+        '"': '&quot;',
+      })[c] as string,
+  )
+}
+
+export async function GET() {
+  const posts = (await getAllPostsMeta()).sort((a, b) =>
+    a.date < b.date ? 1 : -1,
+  )
+
+  const items = posts
+    .map(
+      (post) => `
+    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE}/articles/${post.slug}</link>
+      <guid>${SITE}/articles/${post.slug}</guid>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <description>${escapeXml(post.description)}</description>
+    </item>`,
+    )
+    .join('')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Azaz Ahamed</title>
+    <link>${SITE}</link>
+    <description>Articles by Azaz Ahamed — full-stack &amp; systems engineering.</description>
+    <language>en</language>
+    <atom:link href="${SITE}/feed.xml" rel="self" type="application/rss+xml" />${items}
+  </channel>
+</rss>`
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,20 @@
+import { Metadata } from 'next'
 import { Inter, JetBrains_Mono } from 'next/font/google'
 import React from 'react'
 
 import '@/styles/globals.css'
 
 import Providers from '@/lib/context/Providers'
+import { getAllPostsMeta } from '@/lib/mdx'
 
 import { SiteFrame } from '@/components/layout/SiteFrame'
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://azazahamed.com'),
+  alternates: {
+    types: { 'application/rss+xml': '/feed.xml' },
+  },
+}
 
 const inter = Inter({
   weight: ['400', '500', '600', '700', '800', '900'],
@@ -21,7 +30,15 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
 })
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const articles = (await getAllPostsMeta())
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .map(({ title, slug, description }) => ({ title, slug, description }))
+
   return (
     <html
       lang='en'
@@ -30,7 +47,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     >
       <body className='flex h-full flex-col bg-zinc-50 dark:bg-ink-950'>
         <Providers>
-          <SiteFrame>{children}</SiteFrame>
+          <SiteFrame articles={articles}>{children}</SiteFrame>
         </Providers>
       </body>
     </html>

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from 'next/og'
+
+export const alt = 'Azaz Ahamed — full-stack & systems engineer'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// Default OG image for any route without its own.
+export default function Image() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px',
+        background: '#0B0E14',
+        color: '#E6EAF2',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', fontSize: 30 }}>
+        <span style={{ color: '#5b6472' }}>{'// '}</span>
+        <span style={{ color: '#38E1C6' }}>full-stack · systems engineer</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 84,
+            fontWeight: 800,
+            letterSpacing: '-0.03em',
+          }}
+        >
+          Azaz Ahamed
+        </div>
+        <div style={{ display: 'flex', fontSize: 36, color: '#8A93A6' }}>
+          I build systems that scale.
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', fontSize: 28 }}>
+        <div
+          style={{
+            width: 44,
+            height: 3,
+            background: '#38E1C6',
+            marginRight: 20,
+          }}
+        />
+        <span style={{ color: '#8A93A6' }}>azazahamed.com</span>
+      </div>
+    </div>,
+    size,
+  )
+}

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -83,14 +83,13 @@ const Seo: FC<SeoProps> = ({
       <meta property='og:site_name' content={meta.siteName} />
       <meta property='og:description' content={meta.description} />
       <meta property='og:title' content={meta.title} />
-      <meta property='og:image' content={meta.image} />
+      {/* og:image / twitter:image come from the dynamic opengraph-image routes */}
 
       {/* Twitter Meta Tags */}
       <meta name='twitter:card' content='summary_large_image' />
       <meta name='twitter:site' content='@azaz_zoha' />
       <meta name='twitter:title' content={meta.title} />
       <meta name='twitter:description' content={meta.description} />
-      <meta name='twitter:image' content={meta.image} />
 
       {/* Date for articles/blog posts */}
       {date && (

--- a/components/articles/MdxPre.tsx
+++ b/components/articles/MdxPre.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+function CopyIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='1.6'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      aria-hidden='true'
+      {...props}
+    >
+      <rect x='9' y='9' width='11' height='11' rx='2' />
+      <path d='M5 15V5a2 2 0 0 1 2-2h10' />
+    </svg>
+  )
+}
+
+function CheckIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='1.8'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      aria-hidden='true'
+      {...props}
+    >
+      <path d='m5 12.5 4.5 4.5L19 7.5' />
+    </svg>
+  )
+}
+
+// Wraps rehype-pretty-code's <pre> with a hover copy button. Passed as the
+// `pre` MDX component in lib/mdx so it applies to every fenced code block.
+export function MdxPre({
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLPreElement>) {
+  const ref = useRef<HTMLPreElement>(null)
+  const [copied, setCopied] = useState(false)
+
+  async function copy() {
+    const text = ref.current?.textContent ?? ''
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // clipboard unavailable (e.g. insecure context) — fail quietly
+    }
+  }
+
+  return (
+    <div className='group relative'>
+      <button
+        type='button'
+        onClick={copy}
+        aria-label={copied ? 'Copied' : 'Copy code'}
+        className='absolute top-3 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-md border border-ink-600 bg-ink-800/80 text-zinc-400 opacity-0 backdrop-blur transition group-hover:opacity-100 hover:border-accent-400/50 hover:text-accent-400 focus-visible:opacity-100'
+      >
+        {copied ? (
+          <CheckIcon className='h-4 w-4 text-accent-400' />
+        ) : (
+          <CopyIcon className='h-4 w-4' />
+        )}
+      </button>
+      <pre ref={ref} {...props}>
+        {children}
+      </pre>
+    </div>
+  )
+}

--- a/components/layout/CommandMenu.tsx
+++ b/components/layout/CommandMenu.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { Command } from 'cmdk'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+export type CommandArticle = {
+  title: string
+  slug: string
+  description: string
+}
+
+const PAGES = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'Articles', href: '/articles' },
+  { label: 'Projects', href: '/projects' },
+  { label: 'Uses', href: '/uses' },
+]
+
+// Open from anywhere with ⌘K / Ctrl+K, or by dispatching `command-menu:open`.
+export function CommandMenu({ articles }: { articles: CommandArticle[] }) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen((prev) => !prev)
+      }
+    }
+    function onOpen() {
+      setOpen(true)
+    }
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('command-menu:open', onOpen)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('command-menu:open', onOpen)
+    }
+  }, [])
+
+  function go(href: string) {
+    setOpen(false)
+    router.push(href)
+  }
+
+  return (
+    <Command.Dialog
+      open={open}
+      onOpenChange={setOpen}
+      label='Search articles and pages'
+      overlayClassName='fixed inset-0 z-50 bg-ink-950/70 backdrop-blur-sm'
+      contentClassName='fixed top-[18%] left-1/2 z-50 w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 overflow-hidden rounded-xl border border-ink-700 bg-ink-900 shadow-2xl'
+    >
+      <Command.Input
+        placeholder='Search articles & pages…'
+        className='w-full border-b border-ink-700 bg-transparent px-4 py-3.5 font-mono text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none'
+      />
+      <Command.List className='max-h-80 overflow-y-auto p-2'>
+        <Command.Empty className='px-3 py-6 text-center font-mono text-sm text-zinc-500'>
+          No results.
+        </Command.Empty>
+
+        <Command.Group heading='Pages'>
+          {PAGES.map((page) => (
+            <Command.Item
+              key={page.href}
+              value={`page ${page.label}`}
+              onSelect={() => go(page.href)}
+              className='flex cursor-pointer items-center gap-2 rounded-md px-3 py-2.5 font-mono text-sm text-zinc-300 aria-selected:bg-ink-800 aria-selected:text-accent-400'
+            >
+              <span className='text-zinc-600'>~/</span>
+              {page.label}
+            </Command.Item>
+          ))}
+        </Command.Group>
+
+        {articles.length > 0 && (
+          <Command.Group heading='Articles'>
+            {articles.map((article) => (
+              <Command.Item
+                key={article.slug}
+                value={`article ${article.title} ${article.description}`}
+                onSelect={() => go(`/articles/${article.slug}`)}
+                className='flex cursor-pointer flex-col items-start gap-0.5 rounded-md px-3 py-2.5 text-zinc-300 aria-selected:bg-ink-800 aria-selected:text-accent-400'
+              >
+                <span className='font-mono text-sm'>{article.title}</span>
+                <span className='line-clamp-1 text-xs text-zinc-500'>
+                  {article.description}
+                </span>
+              </Command.Item>
+            ))}
+          </Command.Group>
+        )}
+      </Command.List>
+    </Command.Dialog>
+  )
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -73,6 +73,23 @@ function MoonIcon(props: React.SVGProps<SVGSVGElement>) {
   )
 }
 
+function SearchIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox='0 0 24 24'
+      fill='none'
+      strokeWidth='1.6'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      aria-hidden='true'
+      {...props}
+    >
+      <circle cx='11' cy='11' r='6.5' />
+      <path d='m16 16 3.5 3.5' />
+    </svg>
+  )
+}
+
 function MobileNavItem({
   href,
   children,
@@ -433,7 +450,17 @@ export function Header() {
                 <MobileNavigation className='pointer-events-auto md:hidden' />
                 <DesktopNavigation className='pointer-events-auto hidden md:block' />
               </div>
-              <div className='flex justify-end md:flex-1'>
+              <div className='flex items-center justify-end gap-2 md:flex-1'>
+                <button
+                  type='button'
+                  aria-label='Search'
+                  onClick={() =>
+                    window.dispatchEvent(new CustomEvent('command-menu:open'))
+                  }
+                  className='group pointer-events-auto rounded-full border border-zinc-200 bg-white/80 px-3 py-2 shadow-lg shadow-zinc-800/5 backdrop-blur transition hover:border-accent-400/50 dark:border-ink-700 dark:bg-ink-900/80 dark:hover:border-accent-400/40'
+                >
+                  <SearchIcon className='h-6 w-6 stroke-zinc-500 transition group-hover:stroke-accent-400 dark:stroke-zinc-400' />
+                </button>
                 <div className='pointer-events-auto'>
                   <ModeToggle />
                 </div>

--- a/components/layout/SiteFrame.tsx
+++ b/components/layout/SiteFrame.tsx
@@ -2,10 +2,20 @@
 
 import { usePathname } from 'next/navigation'
 
+import {
+  type CommandArticle,
+  CommandMenu,
+} from '@/components/layout/CommandMenu'
 import { Footer } from '@/components/layout/Footer'
 import { Header } from '@/components/layout/Header'
 
-export function SiteFrame({ children }: { children: React.ReactNode }) {
+export function SiteFrame({
+  children,
+  articles,
+}: {
+  children: React.ReactNode
+  articles: CommandArticle[]
+}) {
   const pathname = usePathname()
 
   // The Keystatic admin renders its own full-screen UI, so skip the site
@@ -27,6 +37,7 @@ export function SiteFrame({ children }: { children: React.ReactNode }) {
         <main>{children}</main>
         <Footer />
       </div>
+      <CommandMenu articles={articles} />
     </>
   )
 }

--- a/lib/mdx/index.ts
+++ b/lib/mdx/index.ts
@@ -6,6 +6,11 @@ import rehypePrettyCode, {
 } from 'rehype-pretty-code'
 import remarkGfm from 'remark-gfm'
 
+import { MdxPre } from '@/components/articles/MdxPre'
+
+// Custom MDX element overrides (each fenced code block gets a copy button).
+const mdxComponents = { pre: MdxPre }
+
 // Code blocks render on a dark panel in both light and dark site themes
 // (see the `prose` `--tw-prose-pre-bg` in tailwind.config.js), so a single
 // dark Shiki theme is used. Shiki emits inline token colors that override the
@@ -25,8 +30,16 @@ interface PostMeta {
   slug: string
   description: string
   author: string
+  readingTime: number // Estimated minutes to read
   draft?: boolean // Drafts are hidden from the published site (see getAllPostsMeta)
   imageUrl?: string // Optional image URL to store first extracted image
+}
+
+// Rough reading-time estimate (~200 words/min) from the raw MDX body.
+const computeReadingTime = (raw: string): number => {
+  const body = raw.replace(/^---[\s\S]*?---/, '')
+  const words = body.trim().split(/\s+/).filter(Boolean).length
+  return Math.max(1, Math.round(words / 200))
 }
 
 interface PostData {
@@ -64,6 +77,7 @@ export const getPostBySlug = async (slug: string): Promise<PostData> => {
 
     const { frontmatter, content } = await compileMDX({
       source: fileContent,
+      components: mdxComponents,
       options: {
         parseFrontmatter: true,
         mdxOptions: {
@@ -85,6 +99,7 @@ export const getPostBySlug = async (slug: string): Promise<PostData> => {
       meta: {
         ...frontmatter,
         slug: realSlug,
+        readingTime: computeReadingTime(fileContent),
         imageUrl: firstImageUrl, // Store the first image URL if available
       } as PostMeta,
       content,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@keystatic/core": "^0.5.50",
     "@keystatic/next": "^5.0.4",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "next": "^16.2.7",
     "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: ^16.2.7
         version: 16.2.7(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1615,6 +1618,228 @@ packages:
         integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==,
       }
     engines: { node: ^14.18.0 || >=16.0.0 }
+
+  '@radix-ui/primitive@1.1.4':
+    resolution:
+      {
+        integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==,
+      }
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution:
+      {
+        integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution:
+      {
+        integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.16':
+    resolution:
+      {
+        integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.12':
+    resolution:
+      {
+        integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution:
+      {
+        integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.9':
+    resolution:
+      {
+        integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution:
+      {
+        integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.11':
+    resolution:
+      {
+        integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.6':
+    resolution:
+      {
+        integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.5':
+    resolution:
+      {
+        integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.5':
+    resolution:
+      {
+        integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution:
+      {
+        integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution:
+      {
+        integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution:
+      {
+        integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution:
+      {
+        integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution:
+      {
+        integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@react-aria/actiongroup@3.8.1':
     resolution:
@@ -3891,6 +4116,15 @@ packages:
       }
     engines: { node: '>=6' }
 
+  cmdk@1.1.1:
+    resolution:
+      {
+        integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==,
+      }
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   co@4.6.0:
     resolution:
       {
@@ -4185,6 +4419,12 @@ packages:
         integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==,
       }
     engines: { node: '>=8' }
+
+  detect-node-es@1.1.0:
+    resolution:
+      {
+        integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==,
+      }
 
   devlop@1.1.0:
     resolution:
@@ -4906,6 +5146,13 @@ packages:
         integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
       }
     engines: { node: '>= 0.4' }
+
+  get-nonce@1.0.1:
+    resolution:
+      {
+        integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==,
+      }
+    engines: { node: '>=6' }
 
   get-package-type@0.1.0:
     resolution:
@@ -7293,6 +7540,32 @@ packages:
         integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==,
       }
 
+  react-remove-scroll-bar@2.3.8:
+    resolution:
+      {
+        integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution:
+      {
+        integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-rough-notation@1.0.8:
     resolution:
       {
@@ -7309,6 +7582,19 @@ packages:
       }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-style-singleton@2.2.3:
+    resolution:
+      {
+        integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-transition-group@4.4.5:
     resolution:
@@ -8331,6 +8617,32 @@ packages:
     peerDependencies:
       '@urql/core': ^5.0.0
       react: '>= 16.8.0'
+
+  use-callback-ref@1.3.3:
+    resolution:
+      {
+        integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution:
+      {
+        integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution:
@@ -9886,6 +10198,148 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.3.6': {}
+
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slot@1.2.5(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@react-aria/actiongroup@3.8.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -11475,6 +11929,18 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   co@4.6.0: {}
 
   collapse-white-space@2.1.0: {}
@@ -11624,6 +12090,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -12203,6 +12671,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -14060,6 +14530,25 @@ snapshots:
 
   react-is@19.2.7: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   react-rough-notation@1.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -14075,6 +14564,14 @@ snapshots:
       '@swc/helpers': 0.5.15
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
+
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -14832,6 +15329,21 @@ snapshots:
       '@urql/core': 5.2.0(graphql@16.14.2)
       react: 19.2.7
       wonka: 6.3.6
+
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,3 +6,13 @@
 
 /* Class-based dark mode driven by next-themes (`attribute="class"`) */
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Command palette (cmdk) group labels */
+[cmdk-group-heading] {
+  padding: 0.6rem 0.75rem 0.3rem;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(113 113 122); /* zinc-500 */
+}


### PR DESCRIPTION
Stacked on #15 (Keystatic CMS) — merge that first; GitHub will retarget this to `main`.

Adds the article-quality features:

- **Copy button** on every code block — a client `<pre>` wrapper passed into the MDX renderer (`lib/mdx`), shows on hover with a copied-state check.
- **Reading time** — estimated in `lib/mdx` and shown in the article header next to the date.
- **RSS feed** at `/feed.xml` (excludes drafts) + a discovery `<link>` in the root layout.
- **Dynamic OG images** via `next/og`: per-article (renders the title) and a site default, in the Systems/Terminal palette. The `Seo` component no longer hand-sets `og:image`/`twitter:image` (avoids duplicates).
- **⌘K command palette** (`cmdk`) over articles + pages, with a header search button (also opens via `command-menu:open` event).

Verified at runtime: `/feed.xml` returns valid RSS with both posts; OG routes return `image/png`; the article shows reading time + 2 copy buttons; the search button renders. typecheck / lint:strict / format / test / build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)