### PR TITLE
fix: secure the keystatic admin in production

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+// The Keystatic admin is UNAUTHENTICATED in `local` storage mode, and on a
+// deployed server its edits would also go to ephemeral container storage
+// (never committed). So only expose /keystatic in production when GitHub mode
+// is configured — that flow requires a GitHub login and commits to the repo.
+// Otherwise return 404. (In development, local editing stays available.)
+export function proxy() {
+  const isProduction = process.env.NODE_ENV === 'production'
+  const githubModeConfigured = Boolean(
+    process.env.NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG,
+  )
+
+  if (isProduction && !githubModeConfigured) {
+    return new NextResponse('Not Found', { status: 404 })
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/keystatic', '/keystatic/:path*', '/api/keystatic/:path*'],
+}


### PR DESCRIPTION
## Problem (reported on the live site)
- `azazahamed.com/keystatic` is **publicly accessible with no auth**.
- Toggling an article to **Draft doesn't hide it**.

Both have one cause: the deployed CMS runs in **local storage mode** (the `NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG` gate isn't set, since the GitHub App isn't configured yet). Local mode has no authentication and writes to the container's *ephemeral* filesystem — so the admin is open, and edits never commit, never rebuild, and never take effect.

The draft *filter itself is correct* — verified: marking an article `draft: true` and running a production build excludes it from the prerendered routes and the sitemap. It just never runs because local-mode edits don't persist.

## Fix
Add `proxy.ts` (Next 16's middleware successor) that returns **404 for `/keystatic` and `/api/keystatic` in production unless GitHub mode is configured**. GitHub mode requires a GitHub login and commits to the repo (→ rebuild → drafts apply). Local editing via `pnpm dev` is unaffected.

To actually edit in production, set up GitHub mode (GitHub App + the 4 env vars in `.env.example`); the proxy then allows the route.

typecheck / lint / build green; dev `/keystatic` still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)